### PR TITLE
feat(fx): polish hand area UX and lobby info nav

### DIFF
--- a/backend/src/main/java/com/monopoly/fx/MainController.java
+++ b/backend/src/main/java/com/monopoly/fx/MainController.java
@@ -181,6 +181,7 @@ public class MainController {
     @FXML private Button discardButton;
     @FXML private Label handTitleLabel;
     @FXML private Label handHintLabel;
+    @FXML private ScrollPane handScroll;
     @FXML private HBox handStrip;
     @FXML private HBox lowerTableBox;
 
@@ -237,6 +238,10 @@ public class MainController {
             updateSelectedPreview();
             syncActionButtons();
         });
+
+        if (handScroll != null) {
+            handScroll.viewportBoundsProperty().addListener((obs, oldB, newB) -> recomputeHandSpacing());
+        }
 
         trafficArea.setEditable(false);
         randomizeFirstCheck.setSelected(false);
@@ -1187,7 +1192,7 @@ public class MainController {
             CardDisplayData data = CardDisplayData.fromHandCardJson(el.getAsJsonObject());
             CardView view = new CardView(data, cardKindClass(data));
             view.setToggleGroup(handToggleGroup);
-            view.setRotate(Math.max(-8.0, Math.min(8.0, (index - (total - 1) / 2.0) * 1.45)));
+            view.setRotate(Math.max(-6.0, Math.min(6.0, (index - (total - 1) / 2.0) * 1.2)));
             view.setOnMouseClicked(event -> {
                 if (event.getClickCount() >= 2) {
                     quickPlay(data);
@@ -1196,9 +1201,36 @@ public class MainController {
             handStrip.getChildren().add(view);
             index++;
         }
+        recomputeHandSpacing();
         selectedCardLabel.setText(i18n("label.selectCardHint"));
         updateSelectedPreview();
         syncActionButtons();
+    }
+
+    /**
+     * Pick the hand-strip overlap so every card fits the visible width: spread out
+     * when there are few cards, tighten the fan when there are many, so the right
+     * edge never spills under the action pad.
+     */
+    private void recomputeHandSpacing() {
+        int n = handStrip.getChildren().size();
+        if (n <= 1) {
+            handStrip.setSpacing(-32);
+            return;
+        }
+        double cardW = CardView.CARD_WIDTH;
+        double padding = 96; // hand-strip left + right insets
+        double spacing = -32;
+        double avail = handScroll != null && handScroll.getViewportBounds() != null
+                ? handScroll.getViewportBounds().getWidth()
+                : 0;
+        if (avail > cardW + padding) {
+            double step = (avail - padding - cardW) / (n - 1);
+            spacing = step - cardW;
+        }
+        // Always keep a slight overlap (fan look); never overlap into illegibility.
+        spacing = Math.max(-86, Math.min(-12, spacing));
+        handStrip.setSpacing(spacing);
     }
 
     private static String handSignature(JsonArray cards) {

--- a/backend/src/main/java/com/monopoly/fx/ui/CardView.java
+++ b/backend/src/main/java/com/monopoly/fx/ui/CardView.java
@@ -3,8 +3,13 @@ package com.monopoly.fx.ui;
 import com.monopoly.fx.I18n;
 import com.monopoly.fx.presentation.CardDisplayData;
 import com.monopoly.fx.presentation.CardImageCache;
+import javafx.animation.Interpolator;
+import javafx.animation.ParallelTransition;
+import javafx.animation.ScaleTransition;
+import javafx.animation.TranslateTransition;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Cursor;
 import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.Label;
 import javafx.scene.control.ToggleButton;
@@ -14,6 +19,7 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
+import javafx.util.Duration;
 
 /**
  * Visual control for one hand card; styling lives in styles.css.
@@ -23,7 +29,15 @@ public class CardView extends ToggleButton {
     public static final double CARD_WIDTH = 122;
     public static final double CARD_HEIGHT = 205;
 
+    /** Vertical lift (px) for hovered and selected cards; selection lifts higher. */
+    private static final double HOVER_LIFT = -12;
+    private static final double SELECT_LIFT = -20;
+    private static final double HOVER_SCALE = 1.04;
+    private static final double SELECT_SCALE = 1.06;
+    private static final Duration ELEVATE_DURATION = Duration.millis(130);
+
     private final CardDisplayData data;
+    private ParallelTransition elevateAnim;
 
     public CardView(CardDisplayData data, String kindStyleClass) {
         this.data = data;
@@ -34,6 +48,9 @@ public class CardView extends ToggleButton {
         setWrapText(true);
         setMaxWidth(Region.USE_PREF_SIZE);
         setText(null);
+        setCursor(Cursor.HAND);
+        hoverProperty().addListener((obs, was, now) -> applyElevation());
+        selectedProperty().addListener((obs, was, now) -> applyElevation());
 
         javafx.scene.image.Image cardImage = CardImageCache.image(data, CARD_WIDTH * 2, CARD_HEIGHT * 2);
         if (cardImage != null) {
@@ -118,6 +135,32 @@ public class CardView extends ToggleButton {
 
     public CardDisplayData getCardData() {
         return data;
+    }
+
+    /**
+     * Animate the card to its target lift/scale based on hover + selection state.
+     * Selected cards lift highest; hovered (unselected) cards lift a little.
+     * Raised cards are pulled to the front so the fan overlap never hides them.
+     */
+    private void applyElevation() {
+        boolean selected = isSelected();
+        boolean hovered = isHover();
+        double targetY = selected ? SELECT_LIFT : (hovered ? HOVER_LIFT : 0);
+        double targetScale = selected ? SELECT_SCALE : (hovered ? HOVER_SCALE : 1.0);
+        setViewOrder(selected || hovered ? -1 : 0);
+
+        if (elevateAnim != null) {
+            elevateAnim.stop();
+        }
+        TranslateTransition move = new TranslateTransition(ELEVATE_DURATION, this);
+        move.setToY(targetY);
+        move.setInterpolator(Interpolator.EASE_BOTH);
+        ScaleTransition scale = new ScaleTransition(ELEVATE_DURATION, this);
+        scale.setToX(targetScale);
+        scale.setToY(targetScale);
+        scale.setInterpolator(Interpolator.EASE_BOTH);
+        elevateAnim = new ParallelTransition(move, scale);
+        elevateAnim.play();
     }
 
     private static void applyColorBar(Region bar, CardDisplayData d) {

--- a/backend/src/main/resources/com/monopoly/fx/MainView.fxml
+++ b/backend/src/main/resources/com/monopoly/fx/MainView.fxml
@@ -65,7 +65,8 @@
                 </ScrollPane>
 
                 <VBox spacing="10.0" alignment="CENTER" VBox.vgrow="ALWAYS" styleClass="center-table">
-                    <VBox spacing="6.0" alignment="CENTER" VBox.vgrow="ALWAYS" styleClass="center-play-zone">
+                    <VBox spacing="6.0" alignment="CENTER" VBox.vgrow="ALWAYS"
+                          maxWidth="760.0" styleClass="center-play-zone">
                         <VBox fx:id="centerNoticeBox" spacing="4.0" alignment="CENTER"
                               visible="false" managed="false" styleClass="center-notice">
                             <Label fx:id="centerTitleLabel" text="牌桌就绪" styleClass="center-title"/>
@@ -127,11 +128,11 @@
                             <Label fx:id="handTitleLabel" text="手牌" styleClass="section-title"/>
                             <Label fx:id="handHintLabel" text="双击会按默认动作快速出牌。" styleClass="hand-hint"/>
                         </HBox>
-                        <ScrollPane fx:id="handScroll" fitToHeight="true" hbarPolicy="NEVER" vbarPolicy="NEVER"
-                                    prefHeight="212.0" styleClass="hand-scroll">
-                            <HBox fx:id="handStrip" spacing="-48.0" alignment="BOTTOM_CENTER" styleClass="hand-strip">
+                        <ScrollPane fx:id="handScroll" fitToHeight="true" hbarPolicy="AS_NEEDED" vbarPolicy="NEVER"
+                                    prefHeight="250.0" styleClass="hand-scroll">
+                            <HBox fx:id="handStrip" spacing="-32.0" alignment="BOTTOM_CENTER" styleClass="hand-strip">
                                 <padding>
-                                    <Insets bottom="16.0" left="58.0" right="58.0" top="18.0"/>
+                                    <Insets bottom="14.0" left="48.0" right="48.0" top="24.0"/>
                                 </padding>
                             </HBox>
                         </ScrollPane>

--- a/backend/src/main/resources/com/monopoly/fx/styles.css
+++ b/backend/src/main/resources/com/monopoly/fx/styles.css
@@ -125,21 +125,44 @@
 }
 
 .info-tabs {
-    -fx-background-color: rgba(36, 83, 56, 0.10);
-    -fx-padding: 14px;
+    -fx-background-color: rgba(36, 83, 56, 0.08);
+    -fx-padding: 16px 14px;
     -fx-background-radius: 10px 0 0 10px;
+    -fx-spacing: 10px;
 }
 
 .info-tab {
-    -fx-background-color: rgba(255, 255, 255, 0.58);
-    -fx-text-fill: #2f2515;
+    -fx-background-color: rgba(255, 255, 255, 0.62);
+    -fx-background-radius: 10px;
+    -fx-border-color: rgba(58, 42, 20, 0.12);
+    -fx-border-radius: 10px;
+    -fx-text-fill: #4b3d25;
+    -fx-font-size: 13px;
+    -fx-font-weight: 900;
     -fx-alignment: CENTER_LEFT;
-    -fx-min-height: 40px;
+    -fx-padding: 9px 16px;
+    -fx-min-height: 42px;
+    -fx-max-width: Infinity;
+    -fx-pref-width: 9999px;
+    -fx-cursor: hand;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.08), 6, 0.10, 0, 2);
+}
+
+.info-tab:hover {
+    -fx-background-color: rgba(36, 83, 56, 0.18);
+    -fx-text-fill: #1f3a28;
+    -fx-translate-x: 2px;
 }
 
 .info-tab.active {
-    -fx-background-color: #245338;
+    -fx-background-color: linear-gradient(to right, #245338, #2f6b46);
     -fx-text-fill: #fff8d8;
+    -fx-border-color: rgba(255, 244, 190, 0.30);
+    -fx-effect: dropshadow(gaussian, rgba(36, 83, 56, 0.45), 12, 0.30, 0, 3);
+}
+
+.info-tab.active:hover {
+    -fx-translate-x: 0;
 }
 
 .info-copy {
@@ -405,9 +428,9 @@
     -fx-background-radius: 18px;
     -fx-border-color: rgba(255, 244, 190, 0.16);
     -fx-border-radius: 18px;
-    -fx-padding: 8px 12px;
-    -fx-min-height: 108px;
-    -fx-max-height: 180px;
+    -fx-padding: 10px 14px;
+    -fx-min-height: 120px;
+    -fx-max-height: 230px;
     -fx-max-width: 760px;
     -fx-effect: innershadow(gaussian, rgba(0, 0, 0, 0.24), 24, 0.2, 0, 0);
 }
@@ -605,10 +628,15 @@
 }
 
 .hand-panel {
-    -fx-padding: 10px 12px 0 12px;
+    -fx-padding: 10px 14px 6px 14px;
     -fx-min-height: 326px;
     -fx-pref-height: 342px;
-    -fx-background-color: rgba(8, 54, 38, 0.62);
+    -fx-max-height: 342px;
+    -fx-background-color:
+        linear-gradient(to bottom, rgba(14, 66, 46, 0.42), rgba(6, 40, 28, 0.30));
+    -fx-background-radius: 16px;
+    -fx-border-color: rgba(255, 244, 190, 0.14);
+    -fx-border-radius: 16px;
 }
 
 .hand-hint {
@@ -617,7 +645,7 @@
 }
 
 .hand-strip {
-    -fx-min-height: 216px;
+    -fx-min-height: 248px;
 }
 
 .card {
@@ -628,9 +656,13 @@
     -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.34), 12, 0.22, 0, 4);
 }
 
+/* Lift/scale are driven by animation in CardView; CSS only handles glow. */
+.card:hover {
+    -fx-effect: dropshadow(gaussian, rgba(255, 248, 216, 0.55), 18, 0.32, 0, 6);
+}
+
 .card:selected {
-    -fx-translate-y: -18px;
-    -fx-effect: dropshadow(gaussian, rgba(255, 248, 216, 0.86), 20, 0.45, 0, 0);
+    -fx-effect: dropshadow(gaussian, rgba(255, 248, 216, 0.86), 22, 0.5, 0, 2);
 }
 
 .card-face-image {


### PR DESCRIPTION
## Summary

- Hand card hover/select now animates smoothly (translate + scale, 130ms ease); hovered card always renders above its neighbors via `viewOrder`
- Hand strip spacing auto-adapts to viewport width — cards no longer overflow into the action pad
- Fixed `hand-panel` height cap (max 342px) so it no longer juts into the played-card zone; background softened to gradient + subtle border
- `center-play-zone` max-height raised to 230px; inline `maxWidth` on FXML node ensures strict window centering
- Lobby info nav redesigned: rounded pill buttons, hover slide highlight, active state gets green gradient + gold border + drop shadow

## Test plan

- [ ] Start a HVM game, observe hand cards hover/select elevation animation
- [ ] With 7+ cards in hand, confirm none overflow into the action pad (horizontal scroll appears instead)
- [ ] Confirm hand panel top edge stays below the played-card zone during gameplay
- [ ] Open lobby, click each info tab — verify hover highlight and active state styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)